### PR TITLE
Preserve breadcrumbs through projections

### DIFF
--- a/Sources/JAYSON/JSON+OptionalProperty.swift
+++ b/Sources/JAYSON/JSON+OptionalProperty.swift
@@ -27,7 +27,10 @@ extension JSON {
   public var dictionary: [String : JSON]? {
     return (source as? [String : Any])?.reduce([String : JSON]()) { dic, element in
       var dic = dic
-      dic[element.key] = JSON(source: element.value, breadcrumb: nil)
+      dic[element.key] = JSON(
+        source: element.value,
+        breadcrumb: breadcrumb?.appending(.key(element.key)) ?? Breadcrumb(key: element.key)
+      )
       return dic
     }
   }
@@ -36,7 +39,10 @@ extension JSON {
     return (source as? [Any])?
       .enumerated()
       .map {
-        JSON(source: $0.element, breadcrumb: nil)
+        JSON(
+          source: $0.element,
+          breadcrumb: breadcrumb?.appending(.index($0.offset)) ?? Breadcrumb(index: $0.offset)
+        )
     }
   }
 

--- a/Sources/JAYSON/JSON.swift
+++ b/Sources/JAYSON/JSON.swift
@@ -51,7 +51,7 @@ public struct JSON: Hashable, Sendable {
   nonisolated(unsafe)
   public internal(set) var source: Any
 
-  fileprivate let breadcrumb: Breadcrumb?
+  let breadcrumb: Breadcrumb?
 
   public init(_ object: JSONWritableType) {
     source = object.jsonValueBox.source
@@ -452,4 +452,3 @@ extension JSON: Swift.ExpressibleByArrayLiteral {
     self.init(elements)
   }
 }
-

--- a/Tests/JAYSONTests/Tests.swift
+++ b/Tests/JAYSONTests/Tests.swift
@@ -150,6 +150,44 @@ class Tests: XCTestCase {
     }
   }
 
+  func testCurrentPathThroughArrayProjection() {
+    do {
+      let j = try JSON(data: inData)
+      let value = try j
+        .next("tree1")
+        .next("tree2")
+        .next("tree3")
+        .getArray()[0]
+        .next("index")
+
+      XCTAssertEqual(value.currentPath(), #"["tree1"]["tree2"]["tree3"][0]["index"]"#)
+      XCTAssertEqual(value, "myvalue")
+    } catch {
+      XCTFail("\(error)")
+    }
+  }
+
+  func testCurrentPathThroughDictionaryProjection() {
+    do {
+      let j = try JSON(data: inData)
+      let root = try j.getDictionary()
+      let tree1 = try XCTUnwrap(root["tree1"])
+      let tree1Dictionary = try tree1.getDictionary()
+      let tree2 = try XCTUnwrap(tree1Dictionary["tree2"])
+      let tree2Dictionary = try tree2.getDictionary()
+      let tree3 = try XCTUnwrap(tree2Dictionary["tree3"])
+      let tree3Array = try tree3.getArray()
+      let element = try XCTUnwrap(tree3Array.first)
+      let elementDictionary = try element.getDictionary()
+      let value = try XCTUnwrap(elementDictionary["index"])
+
+      XCTAssertEqual(value.currentPath(), #"["tree1"]["tree2"]["tree3"][0]["index"]"#)
+      XCTAssertEqual(value, "myvalue")
+    } catch {
+      XCTFail("\(error)")
+    }
+  }
+
   func testRemove() {
     let j = try! JSON(data: inData)
     let removed = j.removed("tree1")


### PR DESCRIPTION
## Summary
- preserve breadcrumbs when projecting children through dictionary and array accessors
- keep currentPath and JSONError context consistent between next() and getArray()/getDictionary() traversal
- add regression tests for array and dictionary projection paths

## Testing
- swift test